### PR TITLE
Support gitflow-style branch names (with embedded "/")

### DIFF
--- a/git-incoming
+++ b/git-incoming
@@ -12,7 +12,7 @@ if [ "${CURRENT_BRANCH}" != "" ]; then
     # there is a tracking repository
     if [ "${TRACKING_REPOSITORY}" != "" ]; then
       REMOTE_REPOSITORY="${TRACKING_REPOSITORY}"
-      REMOTE_BRANCH="$(git config branch.${CURRENT_BRANCH}.merge | cut -d"/" -f3)"
+      REMOTE_BRANCH="$(git config branch.${CURRENT_BRANCH}.merge | sed -e 's#^[^/]*/[^/]*/##')"
       TARGET="${REMOTE_REPOSITORY}/${REMOTE_BRANCH}"
     fi
   fi

--- a/git-outgoing
+++ b/git-outgoing
@@ -12,7 +12,7 @@ if [ "${CURRENT_BRANCH}" != "" ]; then
     # there is a tracking repository
     if [ "${TRACKING_REPOSITORY}" != "" ]; then
       REMOTE_REPOSITORY="${TRACKING_REPOSITORY}"
-      REMOTE_BRANCH="$(git config branch.${CURRENT_BRANCH}.merge | cut -d"/" -f3)"
+      REMOTE_BRANCH="$(git config branch.${CURRENT_BRANCH}.merge | sed -e 's#^[^/]*/[^/]*/##')"
       TARGET="${REMOTE_REPOSITORY}/${REMOTE_BRANCH}"
     fi
   fi


### PR DESCRIPTION
gitflow - https://github.com/nvie/gitflow - by default uses branch prefixes that include a slash ("/"), as illustrated by the following default settings:

```
gitflow.prefix.feature=feature/
gitflow.prefix.release=release/
gitflow.prefix.hotfix=hotfix/
gitflow.prefix.support=support/
```

This causes `git-incoming` and `git-outgoing` to stop working, though,as they both make the implicit assumption that branch names do not have an embedded "/".

This pull request removes that implicit assumption, and ensures that both scripts work properly for git repos that have gitflow style branch names.
