### PR TITLE
Fix parsing of CURRENT_BRANCH and empty string tests

### DIFF
--- a/git-incoming
+++ b/git-incoming
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-CURRENT_BRANCH=$(git name-rev HEAD | cut -d " " -f2)
+CURRENT_BRANCH=$(git name-rev --name-only --refs="refs/heads/*" `git symbolic-ref -q HEAD`)
 
-if [ "${CURRENT_BRANCH}" != "" ]; then
+if [ -n "${CURRENT_BRANCH}" ]; then
   
   TARGET="${1}"
   

--- a/git-outgoing
+++ b/git-outgoing
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-CURRENT_BRANCH=$(git name-rev HEAD | cut -d " " -f2)
+CURRENT_BRANCH=$(git name-rev --name-only --refs="refs/heads/*" `git symbolic-ref -q HEAD`)
 
-if [ "${CURRENT_BRANCH}" != "" ]; then
+if [ -n "${CURRENT_BRANCH}" ]; then
   
   TARGET="${1}"
   

--- a/git-patch
+++ b/git-patch
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CURRENT_BRANCH=$(git name-rev HEAD | cut -d " " -f2)
+CURRENT_BRANCH=$(git name-rev --name-only --refs="refs/heads/*" `git symbolic-ref -q HEAD`)
 CURRENT_DIR=$(basename $(pwd))
 
 PATCH_DIR="${HOME}/Documents/Patches/${CURRENT_DIR}"

--- a/git-switch
+++ b/git-switch
@@ -6,7 +6,7 @@ fi
 
 
 NEW_BRANCH=${1}
-CURRENT_BRANCH=$(git name-rev HEAD | cut -d " " -f2)
+CURRENT_BRANCH=$(git name-rev --name-only --refs="refs/heads/*" `git symbolic-ref -q HEAD`)
 
 git stash save autostash &>/dev/null
 git checkout ${NEW_BRANCH}


### PR DESCRIPTION
Several commands were failing in my environment. This is just some cleanup that should be safe to run anywhere.
