### PR TITLE
git-incoming/outgoing require bash

### DIFF
--- a/git-incoming
+++ b/git-incoming
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 CURRENT_BRANCH=$(git branch &>/dev/null; if [ $? -eq 0 ]; then echo "$(git branch | grep '^*' |sed s/\*\ //)"; fi)
 

--- a/git-outgoing
+++ b/git-outgoing
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 CURRENT_BRANCH=$(git branch &>/dev/null; if [ $? -eq 0 ]; then echo "$(git branch | grep '^*' |sed s/\*\ //)"; fi)
 


### PR DESCRIPTION
On the latest Debian `/bin/sh` is `dash` not `bash` and these two scripts don't work, so I changed them to use `bash` explicitly.
