### PR TITLE
Use 1 as the default number of commits (git last)

### DIFF
--- a/git-last
+++ b/git-last
@@ -1,3 +1,3 @@
-#!/bin/sh
-REVISIONS=${1}
+#!/bin/bash
+REVISIONS=${1:-1}
 git log -n ${REVISIONS}


### PR DESCRIPTION
This patch sets the default number of commits to 1, in case no number of commits is specified on the command line _(note that this requires the bash shell, as it uses bash-specific shell parameter expansion syntax)_... thus avoiding the following error message:

``` shell
~ $ git last
error: -n requires an argument
~ $ git-last
error: -n requires an argument
~ $ _
```
