### PR TITLE
make git-wtf handle branches with a '/' in them

### DIFF
--- a/git-wtf
+++ b/git-wtf
@@ -95,7 +95,7 @@ current_branch = run_command("git branch").split("\n").detect { |l| l[0,1] == '*
 
 $branches = run_command("git for-each-ref refs/heads").split("\n").inject({}) do |hash, line|
   parts   = line.split(' ')
-  name    = parts.last.split('/').last
+  name    = parts.last.split('/')[2..-1].join('/')
   rev     = parts.first
   current = (name == current_branch)
   version = $config["version_branches"].include?(name)


### PR DESCRIPTION
git-wtf currently assumes the last token in a branch like 'refs/heads/branch-name' is the full branch name, but branches can have a slash in them, like in git-flow 'refs/heads/feature/feature-name'.  

This simple fix makes git-wtf toss out the 'refs/heads' part, and keep the rest, no matter how many '/' chars there are left.
