### PR TITLE
git-wtf: Change delimiter of `git log --pretty` format string to |.

### DIFF
--- a/git-wtf
+++ b/git-wtf
@@ -65,13 +65,13 @@ def run_command(command)
 end
 
 def commits_between from, to
-  commits = run_command(%{ git log --pretty=format:"%h-%ae-%s" #{from}..#{to} }).split(/[\r\n]+/).map do |raw_commit|
-    raw_commit_parts = raw_commit.split('-')
+  commits = run_command(%{ git log --pretty=format:"%h|%ae|%s" #{from}..#{to} }).split(/[\r\n]+/).map do |raw_commit|
+    raw_commit_parts = raw_commit.split('|')
 
     {
       :hash    => raw_commit_parts.shift,
       :author  => raw_commit_parts.shift.split('@').first,
-      :message => raw_commit_parts.join('-')
+      :message => raw_commit_parts.join('|')
     }
   end
   


### PR DESCRIPTION
This prevents e-mail addresses with dashes in them from mangling the output
of the command. | is a safer character than , because it cannot appear in
e-mail addresses or commit IDs.
