### PR TITLE
Improve git-switch

### DIFF
--- a/git-switch
+++ b/git-switch
@@ -2,6 +2,7 @@
 
 if [ "${1}" == "" ]; then
   echo "git-switch <branch> [--all]"
+  exit 1
 fi
 
 

--- a/git-switch
+++ b/git-switch
@@ -24,5 +24,5 @@ fi
 AUTOSTASH=$(git stash list | grep "${NEW_BRANCH}: autostash" | tail -n 1 | cut -d":" -f1)
 
 if [ "${AUTOSTASH}" != "" ]; then
-  git stash apply ${AUTOSTASH} && git stash drop ${AUTOSTASH}
+  git stash apply --index ${AUTOSTASH} && git stash drop ${AUTOSTASH}
 fi


### PR DESCRIPTION
I made two changes to git-switch:

- exit right after displaying usage instructions if no argument is provided
- stash apply should restore other factors of the "index" to preserve git mv commands and merge states